### PR TITLE
Fix: .secrets folder was not populated with firebase-admin-credentials

### DIFF
--- a/.secrets/.gitignore
+++ b/.secrets/.gitignore
@@ -1,0 +1,1 @@
+firebase-admin-credentials.json

--- a/.secrets/README.md
+++ b/.secrets/README.md
@@ -1,0 +1,2 @@
+I am just a placeholder !
+I prevent git from ignoring this folder


### PR DESCRIPTION
This PR makes sure `.secrets/firebase-admin-credentials.json` is populated with correct credentials.