### PR TITLE
Fix: "UNSPECIFIED" Label Shown on All Video Cards

### DIFF
--- a/frontend/webapp/src/components/ListOfVideos.jsx
+++ b/frontend/webapp/src/components/ListOfVideos.jsx
@@ -8,6 +8,7 @@ const VideoCard = ({ video }) => {
     const navigate = useNavigate()
 
     const getStatusBadge = (status) => {
+        if (!status || status === VideoStatus.STATUS_UNSPECIFIED) return null;
         const statusClasses = {
             [VideoStatus.STATUS_PROCESSING]: "badge badge-warning",
             [VideoStatus.STATUS_READY]: "badge badge-success",


### PR DESCRIPTION
"UNSPECIFIED" Label is not showing now
Close #49 