### PR TITLE
adding support for custom upload folder

### DIFF
--- a/backend/mono/config/config.go
+++ b/backend/mono/config/config.go
@@ -51,6 +51,7 @@ func New() (MonolithConfig, error) {
 
 	viper.SetDefault("videoService.db.driver", "sqlite")
 	viper.SetDefault("videoService.db.url", "db.sqlite")
+	viper.SetDefault("videoService.fileStoreDir", "")
 
 	viper.SetDefault("commentService.db.driver", "sqlite")
 	viper.SetDefault("commentService.db.url", "db.sqlite")

--- a/backend/videoservice/config/config.go
+++ b/backend/videoservice/config/config.go
@@ -1,7 +1,8 @@
 package config
 
 type VideoServiceConfig struct {
-	DB DBConfig `json:"db" mapstructure:"db"`
+	DB           DBConfig `json:"db" mapstructure:"db"`
+	FileStoreDir string   `json:"fileStoreDir" mapstructure:"fileStoreDir"`
 }
 
 type DBConfig struct {


### PR DESCRIPTION
These two environment variables are needed in deployment now

```sh
#will create the folder if not exists
export VIDEOSERVICE_FILESTOREDIR=/folder/to/upload 

#need the file name xyz.db at the end
export VIDEOSERVICE_DB_URL=/file/to/db.sqlite
```